### PR TITLE
Some improvements to the world border enforcement thingy

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>org.echo</groupId>
     <artifactId>WorldBorder</artifactId>
-    <version>1.2</version>
+    <version>1.3</version>
     <packaging>jar</packaging>
 
     <name>WorldBorder</name>

--- a/src/main/java/org/echo/worldborder/Border.java
+++ b/src/main/java/org/echo/worldborder/Border.java
@@ -25,20 +25,4 @@ public class Border {
     public int getCenterZ() {
         return centerZ;
     }
-
-    public boolean isInBorder(Location location) {
-
-        int x = location.getBlockX();
-        int z = location.getBlockZ();
-
-        if (x > centerX + (borderSize / 2) - 1)
-            return true;
-        if (x < centerX - (borderSize / 2) + 1)
-            return true;
-        if (z > centerZ + (borderSize / 2) - 1)
-            return true;
-        if (z < centerZ - (borderSize / 2) + 1)
-            return true;
-        return false;
-    }
 }

--- a/src/main/java/org/echo/worldborder/BordersManager.java
+++ b/src/main/java/org/echo/worldborder/BordersManager.java
@@ -1,6 +1,10 @@
 package org.echo.worldborder;
 
-import org.bukkit.*;
+import org.bukkit.Bukkit;
+import org.bukkit.ChatColor;
+import org.bukkit.Location;
+import org.bukkit.World;
+import org.bukkit.WorldBorder;
 
 import java.util.Map;
 

--- a/src/main/java/org/echo/worldborder/BordersManager.java
+++ b/src/main/java/org/echo/worldborder/BordersManager.java
@@ -1,9 +1,6 @@
 package org.echo.worldborder;
 
-import org.bukkit.Bukkit;
-import org.bukkit.ChatColor;
-import org.bukkit.Location;
-import org.bukkit.World;
+import org.bukkit.*;
 
 import java.util.Map;
 
@@ -66,14 +63,28 @@ public class BordersManager {
         }
     }
 
-    public boolean isInBorder(Location location) {
+    public Location clampToBorder(Location location) {
+        WorldBorder border = location.getWorld().getWorldBorder();
+        double borderSize = border.getSize();
+        int centerX = border.getCenter().getBlockX();
+        int centerZ = border.getCenter().getBlockZ();
+        int x = location.getBlockX();
+        int z = location.getBlockZ();
 
-        Border border = plugin.getMyConfig().getBorder(location.getWorld().getName());
+        Location clampedLoc = location.clone();
 
-        if (border != null)
-            if (border.isInBorder(location))
-                return true;
+        if (x >= centerX + (borderSize / 2))
+            clampedLoc.setX((borderSize / 2) - centerX - 1);
 
-        return false;
+        if (x <= centerX - (borderSize / 2))
+            clampedLoc.setX((-borderSize / 2) + centerX + 1);
+
+        if (z >= centerZ + (borderSize / 2))
+            clampedLoc.setZ((borderSize / 2) - centerZ - 1);
+
+        if (z <= centerZ - (borderSize / 2))
+            clampedLoc.setZ((-borderSize / 2) + centerZ + 1);
+
+        return clampedLoc;
     }
 }

--- a/src/main/java/org/echo/worldborder/Main.java
+++ b/src/main/java/org/echo/worldborder/Main.java
@@ -5,6 +5,7 @@ import org.echo.worldborder.commands.Commands;
 import org.echo.worldborder.config.Config;
 import org.echo.worldborder.config.Messages;
 import org.echo.worldborder.listener.TeleportListener;
+import org.echo.worldborder.listener.MovementListener;
 
 public final class Main extends JavaPlugin {
 
@@ -22,6 +23,7 @@ public final class Main extends JavaPlugin {
         getCommand("border").setExecutor(new Commands(this));
         getCommand("worldborder").setExecutor(new Commands(this));
         getServer().getPluginManager().registerEvents(new TeleportListener(this), this);
+        getServer().getPluginManager().registerEvents(new MovementListener(this), this);
     }
 
     @Override
@@ -45,4 +47,5 @@ public final class Main extends JavaPlugin {
     public Messages getMessages() {
         return messages;
     }
+
 }

--- a/src/main/java/org/echo/worldborder/config/Config.java
+++ b/src/main/java/org/echo/worldborder/config/Config.java
@@ -16,7 +16,7 @@ public class Config {
     private YamlConfiguration config;
 
     private Map<String, Border> borders;
-    private boolean isDisableOutOfBorderTeleport;
+    private boolean enforce;
 
     public Config(Main plugin) {
         this.plugin = plugin;
@@ -50,7 +50,7 @@ public class Config {
     }
 
     private void loadConfig() {
-        this.isDisableOutOfBorderTeleport = config.getBoolean("disable-out-of-border-teleport", false);
+        this.enforce = config.getBoolean("enforce", false);
     }
 
     private void loadWorldBorders() {
@@ -105,7 +105,7 @@ public class Config {
         return borders.get(worldName);
     }
 
-    public boolean isDisableOutOfBorderTeleport() {
-        return isDisableOutOfBorderTeleport;
+    public boolean isEnforce() {
+        return enforce;
     }
 }

--- a/src/main/java/org/echo/worldborder/config/Messages.java
+++ b/src/main/java/org/echo/worldborder/config/Messages.java
@@ -60,7 +60,7 @@ public class Messages {
         return getMessage("permission-command");
     }
 
-    public String getOutOfBorderTeleport(String worldName) {
-        return getFormattedMessage("out-of-border-teleport", "{world}", worldName);
+    public String getOutOfBounds(String worldName) {
+        return getFormattedMessage("out-of-bounds", "{world}", worldName);
     }
 }

--- a/src/main/java/org/echo/worldborder/listener/MovementListener.java
+++ b/src/main/java/org/echo/worldborder/listener/MovementListener.java
@@ -1,27 +1,28 @@
 package org.echo.worldborder.listener;
 
+import net.md_5.bungee.api.ChatMessageType;
+import org.bukkit.Location;
 import org.bukkit.WorldBorder;
 import org.bukkit.event.EventHandler;
 import org.bukkit.event.Listener;
-import org.bukkit.event.player.PlayerTeleportEvent;
+import org.bukkit.event.player.PlayerMoveEvent;
 import org.echo.worldborder.Main;
 
-public class TeleportListener implements Listener {
+public class MovementListener implements Listener {
 
     private final Main plugin;
 
-    public TeleportListener(Main plugin) {
-        this.plugin = plugin;
-    }
+    public MovementListener(Main plugin) { this.plugin = plugin; }
 
     @EventHandler
-    public void onPlayerTeleport(PlayerTeleportEvent event) {
+    public void onPlayerMove(PlayerMoveEvent event) {
         if (plugin.getMyConfig().isEnforce()) {
             WorldBorder border = event.getTo().getWorld().getWorldBorder();
             if (!border.isInside(event.getTo())) {
-                event.setTo(plugin.getManager().clampToBorder(event.getTo()));
+                event.getPlayer().teleport(plugin.getManager().clampToBorder(event.getTo()));
                 event.getPlayer().sendMessage(plugin.getMessages().getOutOfBounds(event.getTo().getWorld().getName()));
             }
         }
+
     }
 }

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -23,8 +23,8 @@
 
 # -------- Config --------
 
-# Disable out-of-border teleportation
-disable-out-of-border-teleport: true
+# Strictly enforce the world border. A
+enforce: true
 
 # -------- Borders --------
 

--- a/src/main/resources/messages.yml
+++ b/src/main/resources/messages.yml
@@ -7,9 +7,8 @@
 
 # -------- Messages --------
 
-# When a teleport is out of border
-# - {world} : replaced by the word name
-out-of-border-teleport: "&cYou cannot teleport out of the border into the '&e{world}&c'."
+# When a player attempts to go out of bounds. Use {world} to specify the world name.
+out-of-bounds: "&cYou cannot go that way."
 
 # When sending a non-permitted command
 permission-command: "&cYou do not have access to this command"


### PR DESCRIPTION
- Attempting to teleport beyond the border will now clamp your position rather than cancelling it
- Attempting to fly beyond the border via spectator mode will now also clamp your position to the border. This will work for any case where players move beyond the border.

Breaking changes:
- "disable-out-of-border-teleport" in config.yml was renamed to "enforce" to more accurately reflect its function.
- "out-of-border-teleport" in messages.yml was renamed to "out-of-bounds" to more accurately reflect its function. The default message was also changed to "You cannot go that way" in order to cover both cases where clamping occurs. The "{world}" variable is still accepted.

Misc changes:
- Use Spigots function for determining if a player is in bounds instead of this plugins old function.
- Minor code cleanup.